### PR TITLE
feat: serialization format

### DIFF
--- a/.pw-testrc.js
+++ b/.pw-testrc.js
@@ -3,6 +3,7 @@ import { pathToFileURL } from 'node:url'
 
 // Adds a esbuild plugin so we can resolve file URLs relative to the
 // import.meta.url property.
+
 export default {
   buildConfig: {
     plugins: [
@@ -12,8 +13,8 @@ export default {
           onLoad({ filter: /\.js|\.ts/, namespace: 'file' }, (args) => {
             let code = FS.readFileSync(args.path, 'utf8')
             code = code.replace(
-              /new URL\((.*), import\.meta\.url\)/g,
-              `new URL(\$1, ${JSON.stringify(pathToFileURL(args.path))})`
+              /import\.meta\.url/g,
+              JSON.stringify(pathToFileURL(args.path))
             )
             return { contents: code }
           })

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -205,15 +205,13 @@ class Aggregate {
     this.limit = limit
     this.size = size
     this.offset = offset
+    this.link = Piece.createLink(this.tree.root)
   }
   /**
    * Size of the index in bytes.
    */
   get indexSize() {
     return this.limit * EntrySize
-  }
-  link() {
-    return Piece.createLink(this.tree.root)
   }
   /**
    * Height of the perfect binary merkle tree corresponding to this aggregate.
@@ -223,7 +221,7 @@ class Aggregate {
   }
   toJSON() {
     return {
-      link: { '/': this.link().toString() },
+      link: { '/': this.link.toString() },
       height: this.height,
     }
   }

--- a/src/fr32.js
+++ b/src/fr32.js
@@ -47,12 +47,12 @@ const FR_RATIO = IN_BITS_FR / OUT_BITS_FR
  */
 export function toZeroPaddedSize(sourceSize) {
   const size = Math.max(sourceSize, MIN_PIECE_SIZE)
-  let highestBit = Math.floor(Math.log2(size))
+  const highestBit = Math.floor(Math.log2(size))
 
-  const bound = Math.ceil(FR_RATIO * (1 << (highestBit + 1)))
+  const bound = Math.ceil(FR_RATIO * 2 ** (highestBit + 1))
   // the size is either the closest pow2 number, or the next pow2 number if we
   // don't have space for padding
-  return size <= bound ? bound : Math.ceil(FR_RATIO * (1 << (highestBit + 2)))
+  return size <= bound ? bound : Math.ceil(FR_RATIO * 2 ** (highestBit + 2))
 }
 
 /**

--- a/src/piece/padded-size.js
+++ b/src/piece/padded-size.js
@@ -1,5 +1,8 @@
 import * as API from '../api.js'
-import { onesCount64 } from '../uint64.js'
+import { onesCount64, log2Ceil } from '../uint64.js'
+import * as Node from '../node.js'
+
+const NODE_SIZE = BigInt(Node.Size)
 
 /**
  * Validates that given `size` is a valid {@link API.PaddedPieceSize} and
@@ -48,3 +51,10 @@ export const validate = (size) => {
  * @returns {API.UnpaddedPieceSize}
  */
 export const toUnpaddedSize = (size) => size - size / 128n
+
+/**
+ * Calculates the height of the piece tree from unpadded size.
+ *
+ * @param {API.PaddedPieceSize} size
+ */
+export const toHeight = (size) => log2Ceil(size / NODE_SIZE)

--- a/src/piece/tree.js
+++ b/src/piece/tree.js
@@ -3,9 +3,13 @@ import { Size as NodeSize } from '../node.js'
 import * as Proof from '../proof.js'
 export { computeNode } from '../proof.js'
 
+// The value is an unsigned, 32-bit integer that is always numerically greater
+// than the highest index in the array. This means our tree can represent a
+// piece up to 128 GiB in size.
+export const MAX_LEAF_COUNT = 2 ** 32 - 1
+
 /**
- * `newBareTree` allocates that memory needed to construct a tree with a
- * specific amount of leafs.
+ * Allocates a tree for a given amount of leafs.
  *
  * The construction rounds the amount of leafs up to the nearest two-power with
  * zeroed nodes to ensure that the tree is perfect and hence all internal node's
@@ -13,19 +17,23 @@ export { computeNode } from '../proof.js'
  *
  * @param {number} leafs
  */
-export function newBareTree(leafs) {
-  const adjustedLeafs = 1 << Math.ceil(Math.log2(leafs))
-  /** @type {API.TreeData} */
-  const tree = {
-    nodes: new Array(Math.ceil(Math.log2(adjustedLeafs)) + 1),
-    leafs: leafs,
+export function allocate(leafs) {
+  const adjustedLeafs = 2 ** Math.ceil(Math.log2(leafs))
+
+  if (adjustedLeafs > MAX_LEAF_COUNT) {
+    throw new RangeError(
+      `too many leafs ${adjustedLeafs} exceeds ${MAX_LEAF_COUNT} limit`
+    )
   }
 
-  for (const level of tree.nodes.keys()) {
-    tree.nodes[level] = new Array(1 << level)
+  const height = Math.ceil(Math.log2(adjustedLeafs))
+  const nodes = new Array(height + 1)
+
+  for (const level of nodes.keys()) {
+    nodes[level] = new Array(1 << level)
   }
 
-  return tree
+  return new PieceTree({ nodes, height })
 }
 
 /**
@@ -62,26 +70,26 @@ export const split = (source) => {
 /**
  * @param {API.Fr23Padded} source
  */
-export const build = (source) => buildFromChunks(split(source))
+export const build = (source) => fromChunks(split(source))
 
 /**
  * @param {API.MerkleTreeNode[]} chunks
  */
-export const buildFromChunks = (chunks) => {
+export const fromChunks = (chunks) => {
   if (chunks.length === 0) {
     throw new RangeError('Empty source')
   }
 
   const leafs = chunks //await Promise.all(chunks.map(truncatedHash))
-  return buildFromLeafs(leafs)
+  return fromLeafs(leafs)
 }
 
 /**
  * @param {API.MerkleTreeNode[]} leafs
  * @returns {API.PieceTree}
  */
-export const buildFromLeafs = (leafs) => {
-  const tree = newBareTree(leafs.length)
+export const fromLeafs = (leafs) => {
+  const tree = allocate(leafs.length)
   // Set the padded leaf nodes
   tree.nodes[depth(tree) - 1] = padLeafs(leafs)
   let parentNodes = tree.nodes[depth(tree) - 1]
@@ -116,26 +124,32 @@ export const padLeafs = (leafs) => {
   return [...leafs, ...paddingLeafs]
 }
 
+/**
+ * @implements {API.PieceTree}
+ */
 class PieceTree {
   /**
-   * @param {API.TreeData} model
+   * @param {object} data
+   * @param {API.MerkleTreeNode[][]} data.nodes
+   * @param {number} data.height
    */
-  constructor(model) {
-    this.model = model
+  constructor({ nodes, height }) {
+    this.nodes = nodes
+    this.height = height
   }
 
   get root() {
-    return root(this.model)
+    return root(this)
   }
   get depth() {
-    return depth(this.model)
+    return depth(this)
   }
   get leafs() {
-    const { nodes } = this.model
+    const { nodes } = this
     return nodes[nodes.length - 1]
   }
   get leafCount() {
-    return this.model.leafs
+    return 2 ** this.height
   }
   /**
    *
@@ -143,7 +157,7 @@ class PieceTree {
    * @param {number} index
    */
   node(level, index) {
-    const { nodes } = this.model
+    const { nodes } = this
     return nodes[level][index]
   }
 }

--- a/src/piece/tree.js
+++ b/src/piece/tree.js
@@ -39,7 +39,7 @@ export function allocate(leafs) {
 /**
  * @param {API.TreeData} tree
  */
-export const depth = (tree) => {
+const depth = (tree) => {
   return tree.nodes.length
 }
 
@@ -140,9 +140,6 @@ class PieceTree {
 
   get root() {
     return root(this)
-  }
-  get depth() {
-    return depth(this)
   }
   get leafs() {
     const { nodes } = this

--- a/src/piece/unpadded-size.js
+++ b/src/piece/unpadded-size.js
@@ -1,5 +1,8 @@
 import * as API from '../api.js'
-import { trailingZeros64 } from '../uint64.js'
+import { trailingZeros64, log2Ceil } from '../uint64.js'
+import * as Node from '../node.js'
+
+const NODE_SIZE = BigInt(Node.Size)
 
 /**
  * Validates that given `size` is a valid {@link API.UnpaddedPieceSize} and
@@ -60,3 +63,10 @@ export const validate = (size) => {
  * @returns {API.PaddedPieceSize}
  */
 export const toPaddedSize = (size) => size + size / 127n
+
+/**
+ * Calculates the height of the piece tree from unpadded size.
+ *
+ * @param {API.UnpaddedPieceSize} size
+ */
+export const toHeight = (size) => log2Ceil(toPaddedSize(size) / NODE_SIZE)

--- a/test/aggregate-tree.spec.js
+++ b/test/aggregate-tree.spec.js
@@ -11,7 +11,7 @@ import * as Proof from '../src/proof.js'
  */
 export const testAggregateTree = {
   'basic aggregate tree test': async (assert) => {
-    const piece = PieceTree.buildFromLeafs([
+    const piece = PieceTree.fromLeafs([
       Node.of(0x1),
       Node.empty(),
       Node.empty(),
@@ -32,11 +32,11 @@ export const testAggregateTree = {
     assert.deepEqual(aggregate.leafCount, BigInt(piece.leafCount))
     // depth is the same
 
-    assert.deepEqual(aggregate.depth, piece.depth)
+    assert.deepEqual(aggregate.height, piece.height)
   },
 
   'aggregate tree with left padding': async (assert) => {
-    const piece = PieceTree.buildFromLeafs([
+    const piece = PieceTree.fromLeafs([
       Node.empty(),
       Node.empty(),
       Node.empty(),
@@ -162,7 +162,7 @@ export const testAggregateTree = {
 
   'hybrid with 0 leafs': (assert) => {
     const hybrid = AggregateTree.create(0)
-    assert.deepEqual(hybrid.depth, 1)
+    assert.deepEqual(hybrid.height, 0)
     assert.deepEqual(hybrid.root, Node.empty())
 
     assert.throws(() => hybrid.node(61, 0n), /level too high/)
@@ -213,14 +213,14 @@ export const testAggregateTree = {
   },
 
   'can clear tree': (assert) => {
-    const nonEmpty = PieceTree.buildFromLeafs([
+    const nonEmpty = PieceTree.fromLeafs([
       Node.empty(),
       Node.empty(),
       Node.empty(),
       Node.of(0x1),
     ])
 
-    const empty = PieceTree.buildFromLeafs([
+    const empty = PieceTree.fromLeafs([
       Node.empty(),
       Node.empty(),
       Node.empty(),

--- a/test/aggregate.spec.js
+++ b/test/aggregate.spec.js
@@ -3,6 +3,7 @@ import * as Dataset from './piece/vector.js'
 import * as Piece from '../src/piece.js'
 import * as Link from 'multiformats/link'
 import * as Node from '../src/node.js'
+import * as API from '../src/api.js'
 
 /**
  * @type {import("entail").Suite}
@@ -27,7 +28,7 @@ export const testAggregate = {
       Link.parse(
         'baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq'
       ),
-      build.link()
+      build.link
     )
   },
 
@@ -49,7 +50,7 @@ export const testAggregate = {
       Link.parse(
         'baga6ea4seaqko3i6w4rij37dqerctuv4kbakbcylpe6weeu3tjp26fqyd6txcjy'
       ).toString(),
-      build.link().toString()
+      build.link.toString()
     )
   },
   'basic with two pieces': async (assert) => {
@@ -68,7 +69,7 @@ export const testAggregate = {
       Link.parse(
         'baga6ea4seaqko3i6w4rij37dqerctuv4kbakbcylpe6weeu3tjp26fqyd6txcjy'
       ),
-      builder.build().link()
+      builder.build().link
     )
 
     builder.write(
@@ -90,7 +91,7 @@ export const testAggregate = {
       Link.parse(
         'baga6ea4seaqnqkeoqevjjjfe46wo2lpfclcbmkyms4wkz5srou3vzmr3w3c72bq'
       ),
-      build.link()
+      build.link
     )
 
     assert.equal(build.size, 1n << 20n)
@@ -101,7 +102,7 @@ export const testAggregate = {
     assert.deepEqual(
       JSON.stringify(build),
       JSON.stringify({
-        link: build.link(),
+        link: build.link,
         height: Math.log2((1 << 20) / Node.Size),
       })
     )
@@ -178,7 +179,7 @@ export const testAggregate = {
       Link.parse(
         'baga6ea4seaqd6rv4mrnqpi7kfqcpazxzhho7pytj3v3woh46dzq2hi3zpztfcjy'
       ),
-      build.link()
+      build.link
     )
   },
 
@@ -254,7 +255,7 @@ export const testAggregate = {
       Link.parse(
         'baga6ea4seaqnqkeoqevjjjfe46wo2lpfclcbmkyms4wkz5srou3vzmr3w3c72bq'
       ),
-      build.link()
+      build.link
     )
 
     assert.equal(build.size, 1n << 20n)
@@ -264,7 +265,7 @@ export const testAggregate = {
     assert.deepEqual(
       JSON.stringify(build),
       JSON.stringify({
-        link: build.link(),
+        link: build.link,
         height: Math.log2((1 << 20) / Node.Size),
       })
     )

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -6,6 +6,7 @@ import * as Link from 'multiformats/link'
  */
 export const testLib = {
   'test aggregate sample': async (assert) => {
+    /** @type {Lib.PieceInfo[]} */
     const pieces = [
       {
         link: Link.parse(

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -8,17 +8,17 @@ export const testLib = {
   'test aggregate sample': async (assert) => {
     const pieces = [
       {
-        root: Link.parse(
+        link: Link.parse(
           'baga6ea4seaqae5ysjdbsr4b5jhotaz5ooh62jrrdbxwygfpkkfjz44kvywycmgy'
-        ).multihash.digest,
+        ),
         size: Lib.Piece.UnpaddedSize.toPaddedSize(
           Lib.Piece.UnpaddedSize.from(520192)
         ),
       },
       {
-        root: Link.parse(
+        link: Link.parse(
           `baga6ea4seaqnrm2n2g4m23t6rs26obxjw2tjtr7tcho24gepj2naqhevytduyoa`
-        ).multihash.digest,
+        ),
         size: Lib.Piece.UnpaddedSize.toPaddedSize(
           Lib.Piece.UnpaddedSize.from(260096)
         ),

--- a/test/piece-tree.spec.js
+++ b/test/piece-tree.spec.js
@@ -17,7 +17,7 @@ export const testTree = {
 
   'builds from chunks': async (assert) => {
     const tree = await Tree.build(new Uint8Array(128))
-    assert.equal(tree.depth, 3)
+    assert.equal(tree.height, 2)
     assert.equal(tree.leafs.length, 4)
     assert.equal(tree.node(0, 0), tree.root)
     assert.equal(tree.leafCount, 4)

--- a/test/piece-tree.spec.js
+++ b/test/piece-tree.spec.js
@@ -1,5 +1,4 @@
 import { Tree } from '@web3-storage/data-segment'
-import { base16 } from 'multiformats/bases/base16'
 
 /**
  * @type {import("entail").Suite}
@@ -8,7 +7,7 @@ export const testTree = {
   'throws on empty tree': async (assert) => {
     let result = null
     try {
-      result = Tree.buildFromChunks([])
+      result = Tree.fromChunks([])
     } catch (error) {
       result = { catch: error }
     }
@@ -22,5 +21,8 @@ export const testTree = {
     assert.equal(tree.leafs.length, 4)
     assert.equal(tree.node(0, 0), tree.root)
     assert.equal(tree.leafCount, 4)
+  },
+  'throws when exceeding max leaf count': async (assert) => {
+    assert.throws(() => Tree.allocate(2 ** 32), /too many leafs/)
   },
 }

--- a/test/piece.spec.js
+++ b/test/piece.spec.js
@@ -1,4 +1,4 @@
-import { Piece } from '@web3-storage/data-segment'
+import { Piece, Node } from '@web3-storage/data-segment'
 import { deriveBuffer } from './util.js'
 import * as SHA256 from 'sync-multihash-sha2/sha256'
 import * as raw from 'multiformats/codecs/raw'
@@ -24,7 +24,7 @@ export const testPiece = {
     }
 
     assert.ok(
-      String(result).includes('not defined for inputs shorter than 65 bytes')
+      String(result).includes('not defined for payloads smaller than 65 bytes')
     )
   },
   ...Object.fromEntries(
@@ -32,20 +32,63 @@ export const testPiece = {
       `${data.in.contentSize}\t\t${data.in.cid}`,
       async (assert) => {
         const source = deriveBuffer(data.in.contentSize)
-        const link = createLink(raw.code, SHA256.digest(raw.encode(source)))
+        const root = SHA256.digest(raw.encode(source))
+        const link = createLink(raw.code, root)
         const piece = await Piece.build(source)
         assert.deepEqual(link.toString(), data.in.cid, 'same source content')
-        assert.deepEqual(piece.root, parseLink(data.out.cid).multihash.digest)
+        assert.deepEqual(
+          piece.tree.root,
+          parseLink(data.out.cid).multihash.digest
+        )
+        assert.deepEqual(parseLink(data.out.cid), piece.link)
+        assert.deepEqual(piece.size, BigInt(data.out.size))
+        assert.deepEqual(piece.height, Math.log2(data.out.size / Node.Size))
+        assert.deepEqual(piece.paddedSize, data.out.paddedSize)
 
-        assert.deepEqual(piece.toJSON(), {
+        const json = piece.toJSON()
+
+        assert.deepEqual(json, {
           link: {
             '/': data.out.cid,
           },
-          contentSize: data.in.contentSize,
-          paddedSize: data.out.paddedSize,
-          size: data.out.size,
+          height: Math.log2(data.out.size / Node.Size),
         })
+
+        const view = Piece.fromJSON(json)
+        assert.deepEqual(view.link, piece.link)
+        assert.deepEqual(view.size, piece.size)
+        assert.deepEqual(view.height, piece.height)
       },
     ])
   ),
+
+  'throws if payload is too large': async (assert) => {
+    // Subclass Uint8Array as we can't actually allocate a buffer this large
+    class HugePayload extends Uint8Array {
+      get length() {
+        return Piece.MAX_PAYLOAD_SIZE + 1
+      }
+    }
+
+    assert.throws(
+      () => Piece.build(new HugePayload()),
+      /Payload exceeds maximum supported size/
+    )
+  },
+
+  'toString <-> fromString': async (assert) => {
+    const source = deriveBuffer(128)
+    const piece = await Piece.build(source)
+
+    const serialized = piece.toString()
+    assert.deepEqual(JSON.parse(serialized), {
+      link: { '/': piece.link.toString() },
+      height: piece.height,
+    })
+
+    const deserialized = Piece.fromString(serialized)
+    assert.deepEqual(deserialized.link, piece.link)
+    assert.deepEqual(deserialized.size, piece.size)
+    assert.deepEqual(deserialized.height, piece.height)
+  },
 }

--- a/test/piece/vector.js
+++ b/test/piece/vector.js
@@ -35,5 +35,5 @@ export const createNodeFromInt = (n) => {
 
 export const pieces = sizes.map((size, index) => ({
   size: Piece.PaddedSize.from(size),
-  root: createNodeFromInt(index),
+  link: Piece.createLink(createNodeFromInt(index)),
 }))


### PR DESCRIPTION
This pr updates piece and aggregate serialization format from `{ link, size }` to `{ link, height }`. This allows need for bigints that are problematic in JSON. Since both are perfect binary trees, leaf count of can be derived as `2 ** height`, and the size of the tree can be derived by `leafCount * Node.Size` (32).

Additionally I've also added bit more code to make piece encode / decode easy, which will need to do quite a bit. 