### PR TITLE
feat!: `digestInto` returns bytes written

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -95,7 +95,7 @@ export interface StreamingHasher<
    * at the given offset. Unless `asMultihash` is `false` multihash is
    * written otherwise only the digest (without multihash prefix) is written.
    *
-   * Returns the offset + number of bytes written.
+   * Returns the number of bytes that were written.
    */
   digestInto(output: Uint8Array, offset?: number, asMultihash?: boolean): number
 

--- a/src/digest.js
+++ b/src/digest.js
@@ -37,10 +37,11 @@ export const HEIGHT_SIZE = 1
  * Amount of bytes used to store the tree root.
  */
 export const ROOT_SIZE = SHA256.size
+
 /**
  * Size of the multihash digest in bytes.
  */
-const MAX_DIGEST_SIZE = MAX_PADDING_SIZE + HEIGHT_SIZE + SHA256.size
+export const MAX_DIGEST_SIZE = MAX_PADDING_SIZE + HEIGHT_SIZE + SHA256.size
 
 export const TAG_SIZE = varint.encodingLength(code)
 

--- a/src/multihash.js
+++ b/src/multihash.js
@@ -166,29 +166,31 @@ class Hasher {
       /** @type {number & bigint} */ (padding)
     )
 
+    let endOffset = byteOffset
     // Write the multihash prefix if requested
     if (asMultihash) {
-      varint.encodeTo(code, output, byteOffset)
-      byteOffset += Digest.TAG_SIZE
+      varint.encodeTo(code, output, endOffset)
+      endOffset += Digest.TAG_SIZE
 
       const size = paddingLength + Digest.HEIGHT_SIZE + Digest.ROOT_SIZE
       const sizeLength = varint.encodingLength(size)
-      varint.encodeTo(size, output, byteOffset)
-      byteOffset += sizeLength
+      varint.encodeTo(size, output, endOffset)
+      endOffset += sizeLength
     }
 
-    varint.encodeTo(padding, output, byteOffset)
-    byteOffset += paddingLength
+    varint.encodeTo(padding, output, endOffset)
+    endOffset += paddingLength
 
     // Write the tree height as the first byte of the digest
-    output[byteOffset] = height
-    byteOffset += 1
+    output[endOffset] = height
+    endOffset += 1
 
     // Write the root as the remaining 32 bytes of the digest
-    output.set(root, byteOffset)
-    byteOffset += root.length
+    output.set(root, endOffset)
+    endOffset += root.length
 
-    return byteOffset
+    // Return number of bytes written
+    return endOffset - byteOffset
   }
   /**
    * @param {Uint8Array} bytes

--- a/test/multihash.spec.js
+++ b/test/multihash.spec.js
@@ -29,10 +29,66 @@ export const testMultihashCompat = {
     hasher.write(bytes)
 
     const digest = new Uint8Array(37)
-    hasher.digestInto(digest, 0, true)
+    let count = hasher.digestInto(digest, 0, true)
+
+    assert.deepEqual(count, prefix.length + 1 + 34)
 
     assert.deepEqual(
       digest,
+      new Uint8Array([
+        ...prefix,
+        34, // size
+        62, // padding
+        2, // height
+        55,
+        49,
+        187,
+        153,
+        172,
+        104,
+        159,
+        102,
+        238,
+        245,
+        151,
+        62,
+        74,
+        148,
+        218,
+        24,
+        143,
+        77,
+        220,
+        174,
+        88,
+        7,
+        36,
+        252,
+        111,
+        63,
+        214,
+        13,
+        253,
+        72,
+        131,
+        51,
+      ])
+    )
+  },
+
+  testDigestWithOffset: async (assert) => {
+    const hasher = Hasher.create()
+    const bytes = new Uint8Array(65).fill(0)
+    hasher.write(bytes)
+
+    const digest = new Uint8Array(50)
+    let byteOffset = 7
+    let byteLength = hasher.digestInto(digest, byteOffset, true)
+
+    assert.deepEqual(byteLength, prefix.length + 1 + 34)
+
+    assert.deepEqual(
+      digest.subarray(byteOffset, byteOffset + byteLength),
       new Uint8Array([
         ...prefix,
         34, // size


### PR DESCRIPTION
Followup [on request to change `digestInto` so it returns number of bytes written](https://github.com/web3-storage/fr32-sha2-256-trunc254-padded-binary-tree-multihash/pull/20#discussion_r1372613487)

This changes API so that instead of returning an `endOffset` we return number of bytes written.