### PR TITLE
feat: export JS hasher

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
     "./piece/size": {
       "types": "./dist/src/piece/size.d.ts",
       "import": "./src/piece/size.js"
+    },
+    "./multihash": {
+      "types": "./dist/src/multihash.d.ts",
+      "import": "./src/multihash.js"
     }
   },
   "c8": {


### PR DESCRIPTION
Exports the JS hasher, so it can be used in place of `fr32-sha2-256-trunc254-padded-binary-tree-multihash` (which has the same interface).