### PR TITLE
feat: custom SHA256 hashing function for aggregate builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check": "tsc --build"
   },
   "dependencies": {
-    "@ipld/dag-cbor": "^9.0.5",
+    "@ipld/dag-cbor": "^9.2.1",
     "multiformats": "^13.3.0",
     "sync-multihash-sha2": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,18 +32,18 @@
     "check": "tsc --build"
   },
   "dependencies": {
-    "multiformats": "^11.0.2",
-    "sync-multihash-sha2": "^1.0.0",
-    "@ipld/dag-cbor": "^9.0.5"
+    "@ipld/dag-cbor": "^9.0.5",
+    "multiformats": "^13.3.0",
+    "sync-multihash-sha2": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "20.2.3",
     "c8": "^7.14.0",
+    "entail": "^2.1.1",
     "nyc": "15.1.0",
     "playwright-test": "git+https://github.com/Gozala/playwright-test.git#feat/process.stdout",
     "prettier": "2.8.8",
-    "typescript": "^5.1.3",
-    "entail": "^2.1.1"
+    "typescript": "^5.1.3"
   },
   "type": "module",
   "main": "src/lib.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@ipld/dag-cbor':
-        specifier: ^9.0.5
-        version: 9.0.5
+        specifier: ^9.2.1
+        version: 9.2.1
       multiformats:
-        specifier: ^11.0.2
-        version: 11.0.2
+        specifier: ^13.3.0
+        version: 13.3.0
       sync-multihash-sha2:
         specifier: ^1.0.0
         version: 1.0.0
@@ -272,8 +272,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ipld/dag-cbor@9.0.5':
-    resolution: {integrity: sha512-TyqgtxEojc98rvxg4NGM+73JzQeM4+tK2VQes/in2mdyhO+1wbGuBijh1tvi9BErQ/dEblxs9v4vEQSX8mFCIw==}
+  '@ipld/dag-cbor@9.2.1':
+    resolution: {integrity: sha512-nyY48yE7r3dnJVlxrdaimrbloh4RokQaNRdI//btfTkcTEZbpmSrbYcBQ4VKTf8ZxXAOUJy4VsRpkJo+y9RTnA==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
   '@istanbuljs/load-nyc-config@1.1.0':
@@ -952,13 +952,8 @@ packages:
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
-  multiformats@11.0.2:
-    resolution: {integrity: sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-
-  multiformats@12.1.1:
-    resolution: {integrity: sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  multiformats@13.3.0:
+    resolution: {integrity: sha512-CBiqvsufgmpo01VT5ze94O+uc+Pbf6f/sThlvWss0sBZmAOu6GQn5usrYV2sf2mr17FWYc0rO8c/CNe2T90QAA==}
 
   nanoid@4.0.2:
     resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
@@ -1608,10 +1603,10 @@ snapshots:
   '@esbuild/win32-x64@0.18.11':
     optional: true
 
-  '@ipld/dag-cbor@9.0.5':
+  '@ipld/dag-cbor@9.2.1':
     dependencies:
       cborg: 4.0.3
-      multiformats: 12.1.1
+      multiformats: 13.3.0
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -2298,9 +2293,7 @@ snapshots:
 
   ms@2.1.2: {}
 
-  multiformats@11.0.2: {}
-
-  multiformats@12.1.1: {}
+  multiformats@13.3.0: {}
 
   nanoid@4.0.2: {}
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,8 +8,10 @@ import type {
 } from 'multiformats'
 import type * as Multihash from './multihash.js'
 import type { Sha256Trunc254Padded, FilCommitmentUnsealed } from './piece.js'
+import { SHA256 } from './ipld.js'
 
 export type RAW_CODE = MulticodecCode<0x55, 'raw'>
+export type SHA256_CODE = typeof SHA256.code
 
 /**
  * Type describes a byte representation of a `Data` encoded using

--- a/src/proof.js
+++ b/src/proof.js
@@ -87,23 +87,28 @@ export function resolveRoot(proof, node) {
 
 /**
  * @param {Uint8Array} payload
+ * @param {object} [options]
+ * @param {API.SyncMultihashHasher<API.SHA256_CODE>} [options.hasher]
  * @returns {API.MerkleTreeNode}
  */
-export function truncatedHash(payload) {
-  const { digest } = SHA256.digest(payload)
+export function truncatedHash(payload, options = {}) {
+  const hasher = options.hasher || SHA256
+  const { digest } = hasher.digest(payload)
   return truncate(digest)
 }
 
 /**
  * @param {API.MerkleTreeNode} left
  * @param {API.MerkleTreeNode} right
+ * @param {object} [options]
+ * @param {API.SyncMultihashHasher<API.SHA256_CODE>} [options.hasher]
  * @returns {API.MerkleTreeNode}
  */
-export const computeNode = (left, right) => {
+export const computeNode = (left, right, options) => {
   const payload = new Uint8Array(left.length + right.length)
   payload.set(left, 0)
   payload.set(right, left.length)
-  return truncatedHash(payload)
+  return truncatedHash(payload, options)
 }
 
 /**


### PR DESCRIPTION
This PR adds an option to the aggregate builder allowing a custom sha256 hashing function to be passed.

The current implementation uses a native JS sha256 hashing function.

I've found locally when creating an aggregate of ~80,000 pieces it can take **~28s**, which is probalematic in lambda as it takes >10 minutes.

Using the [native Node.js sync sha256 hasher](https://nodejs.org/dist/latest/docs/api/crypto.html#cryptohashalgorithm-data-outputencoding) the same operation takes **~11s**.